### PR TITLE
[KAN-6] Add several new endpoints, allow category editing

### DIFF
--- a/backend/src/main/java/com/rikishi/rikishi/controller/ContestantsController.java
+++ b/backend/src/main/java/com/rikishi/rikishi/controller/ContestantsController.java
@@ -1,0 +1,43 @@
+package com.rikishi.rikishi.controller;
+
+import com.rikishi.rikishi.model.User;
+import com.rikishi.rikishi.model.WeightClass;
+import com.rikishi.rikishi.model.entity.Contestant;
+import com.rikishi.rikishi.model.entity.Contestants;
+import com.rikishi.rikishi.provider.ResConfigProvider;
+import com.rikishi.rikishi.service.UsersService;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ContestantsController {
+    private final UsersService usersService;
+    private final ResConfigProvider resConfigProvider;
+
+    ContestantsController(UsersService us, ResConfigProvider rcp) {
+        this.usersService = us;
+        this.resConfigProvider = rcp;
+    }
+
+    @GetMapping("/contestants")
+    public Contestants getContestants() {
+        return new Contestants(
+            usersService.getUsers().stream().map(user -> user.toJson()).toList()
+        );
+    }
+
+    @PutMapping("/contestants/{id}")
+    public void putContestant(@RequestBody Contestant newContestant, @PathVariable Long id) {
+        if (newContestant.id() != id)
+            throw new RuntimeException("contestant id differs");
+
+        WeightClass resolvedWeightClass =
+            resConfigProvider.getWeightClassByName(newContestant.weightCategory()).orElseThrow();
+
+        usersService.addUser(User.fromJson(newContestant, resolvedWeightClass));
+    }
+}

--- a/backend/src/main/java/com/rikishi/rikishi/controller/DuelsController.java
+++ b/backend/src/main/java/com/rikishi/rikishi/controller/DuelsController.java
@@ -1,0 +1,18 @@
+package com.rikishi.rikishi.controller;
+
+import com.rikishi.rikishi.model.entity.Duel;
+import com.rikishi.rikishi.model.entity.Duels;
+
+import java.util.ArrayList;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DuelsController {
+    @GetMapping("/duels")
+    public Duels getDuels() {
+        // TODO: fetch list of duels
+        return new Duels(new ArrayList<Duel>());
+    }
+}

--- a/backend/src/main/java/com/rikishi/rikishi/controller/WeightCategoriesController.java
+++ b/backend/src/main/java/com/rikishi/rikishi/controller/WeightCategoriesController.java
@@ -1,0 +1,24 @@
+package com.rikishi.rikishi.controller;
+
+import com.rikishi.rikishi.model.entity.WeightCategories;
+import com.rikishi.rikishi.provider.ResConfigProvider;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class WeightCategoriesController {
+    private final ResConfigProvider resConfigProvider;
+
+    WeightCategoriesController(ResConfigProvider rcp) {
+        this.resConfigProvider = rcp;
+    }
+
+    @GetMapping("/weightCategories")
+    public WeightCategories getWeightCategories() {
+        return new WeightCategories(
+            resConfigProvider.getWeightClasses().stream()
+                .map(weightClass -> weightClass.name()).toList()
+        );
+    }
+}

--- a/backend/src/main/java/com/rikishi/rikishi/model/User.java
+++ b/backend/src/main/java/com/rikishi/rikishi/model/User.java
@@ -1,5 +1,7 @@
 package com.rikishi.rikishi.model;
 
+import com.rikishi.rikishi.model.entity.Contestant;
+
 public record User(
     long id,
     String name,
@@ -10,4 +12,24 @@ public record User(
     Sex sex,
     String country,
     String photoLink
-) {}
+) {
+    public static User fromJson(Contestant contestant, WeightClass resolvedWeightClass) {
+        return new User(
+            contestant.id(),
+            contestant.name(),
+            contestant.surname(),
+            contestant.age(),
+            contestant.weight(),
+            resolvedWeightClass,
+            Sex.fromString(contestant.sex()).orElseThrow(),
+            contestant.country(),
+            contestant.image()
+        );
+    }
+
+    public Contestant toJson() {
+        return new Contestant(
+            name, surname, sex.toString(), age, weight, weightClass.name(), country, photoLink, id
+        );
+    }
+}

--- a/backend/src/main/java/com/rikishi/rikishi/model/entity/Contestant.java
+++ b/backend/src/main/java/com/rikishi/rikishi/model/entity/Contestant.java
@@ -1,0 +1,14 @@
+package com.rikishi.rikishi.model.entity;
+
+// Json-ready version of User
+public record Contestant(
+    String name,
+    String surname,
+    String sex,
+    int age,
+    double weight,
+    String weightCategory,
+    String country,
+    String image,
+    long id
+) {}

--- a/backend/src/main/java/com/rikishi/rikishi/model/entity/Contestants.java
+++ b/backend/src/main/java/com/rikishi/rikishi/model/entity/Contestants.java
@@ -1,0 +1,7 @@
+package com.rikishi.rikishi.model.entity;
+
+import java.util.List;
+
+public record Contestants(
+    List<Contestant> contestants
+) {}

--- a/backend/src/main/java/com/rikishi/rikishi/model/entity/Duel.java
+++ b/backend/src/main/java/com/rikishi/rikishi/model/entity/Duel.java
@@ -1,0 +1,10 @@
+package com.rikishi.rikishi.model.entity;
+
+public record Duel(
+    long id1Contestant,
+    long id2Contestant,
+    int number,
+    long id,
+    String weightCategory,
+    String winner
+) {}

--- a/backend/src/main/java/com/rikishi/rikishi/model/entity/Duels.java
+++ b/backend/src/main/java/com/rikishi/rikishi/model/entity/Duels.java
@@ -1,0 +1,7 @@
+package com.rikishi.rikishi.model.entity;
+
+import java.util.List;
+
+public record Duels(
+    List<Duel> duels
+) {}

--- a/backend/src/main/java/com/rikishi/rikishi/model/entity/WeightCategories.java
+++ b/backend/src/main/java/com/rikishi/rikishi/model/entity/WeightCategories.java
@@ -1,0 +1,7 @@
+package com.rikishi.rikishi.model.entity;
+
+import java.util.List;
+
+public record WeightCategories(
+    List<String> weightCategories
+) {}

--- a/backend/src/main/java/com/rikishi/rikishi/provider/ConfigProvider.java
+++ b/backend/src/main/java/com/rikishi/rikishi/provider/ConfigProvider.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface ConfigProvider {
     List<WeightClass> getWeightClasses();
     Optional<WeightClass> getWeightClassById(long id);
+    Optional<WeightClass> getWeightClassByName(String name);
 }

--- a/backend/src/main/java/com/rikishi/rikishi/provider/ResConfigProvider.java
+++ b/backend/src/main/java/com/rikishi/rikishi/provider/ResConfigProvider.java
@@ -32,6 +32,13 @@ public class ResConfigProvider implements ConfigProvider {
             .findFirst();
     }
 
+    @Override
+    public Optional<WeightClass> getWeightClassByName(String name) {
+        return config.weightClasses.stream()
+            .filter(weightClass -> weightClass.name().equals(name))
+            .findFirst();
+    }
+
     private record Config(
         List<WeightClass> weightClasses
     ) {}

--- a/backend/src/main/java/com/rikishi/rikishi/service/UsersService.java
+++ b/backend/src/main/java/com/rikishi/rikishi/service/UsersService.java
@@ -1,0 +1,27 @@
+package com.rikishi.rikishi.service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.rikishi.rikishi.model.User;
+
+@Service("us")
+public class UsersService {
+    private static Map<Long, User> users = new HashMap<>();
+
+    public void addUser(User user) {
+        users.put(user.id(), user);
+    }
+
+    public List<User> getUsers() {
+        return users.values().stream().toList();
+    }
+
+    public Optional<User> getUserById(long id) {
+        return users.containsKey(id) ? Optional.of(users.get(id)) : Optional.empty();
+    }
+}


### PR DESCRIPTION
This PR:
* adds a service for keeping track of the `Users` (contestants)
* adds the following endpoints: 
  - `GET /contestants` -- list all contestants
  - `PUT /contestants/{id}` -- add new or update existing contestant
    * Request body contains the same JSON as returned by `/contestants` (for a single contestant)
    * Can edit the weight category by changing the appropriate field
    * The `id` passed as path parameter must match the contestant's `id` present in the request body JSON
    * Returns 200 if addition/change successful, 500 otherwise
  - `GET weightCategories` -- list names of all registered weight categories
  - `GET /duels` (unimplemented)